### PR TITLE
Round strike zone height from statsapi to 2 decimal places

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,6 +1,6 @@
 Package: sabRmetrics
 Title: Query {statsapi,baseballsavant}.mlb.com and fit fundamental sabermetric models
-Version: 1.1.0
+Version: 1.2.0
 Authors@R: 
     person("Scott", "Powers", email = "scott.powers@rice.edu", role = c("aut", "cre"))
 Description: The highest-fidelity raw MLB data are available from statsapi.mlb.com and baseballsavant.mlb.com, and some minor league data are available from these APIs as well. This package provides functions to query those APIs, returning the data in a collection of well-factored tables (as opposed to returning a single table). Additionally, this package offers functions to estimate base-out run expectancy; estimate count values; and recover the full estimated quadratic trajectory of a pitch from pitch tracking data.

--- a/NEWS.md
+++ b/NEWS.md
@@ -1,12 +1,16 @@
 
+# sabRmetrics 1.2.0 (in development)
+
+- Round strike zone height from statsapi to 2 decimal places
+
 # sabRmetrics 1.1.0 (2025-07-07)
 
 - Add new `download_season_summary()` function
 - Add new `download_player()` function
-- Renamed `extract_schedule()` to `download_schedule()`
+- Rename `extract_schedule()` to `download_schedule()`
 - Include spin rate in `download_statsapi()`
 - Improve handling of schedule gaps in `download_baseballsavant()`
-- Added tests for all download functions
+- Add tests for all download functions
 
 # sabRmetrics 1.0.5 (2024-11-17)
 

--- a/R/extract_game.R
+++ b/R/extract_game.R
@@ -74,8 +74,11 @@ extract_game <- function(game_id) {
     z0 = play_data$pitchData$coordinates$z0,
     extension = replace_null(play_data$pitchData$extension),
     spin_rate = play_data$pitchData$breaks$spinRate,
-    strike_zone_top = play_data$pitchData$strikeZoneTop,
-    strike_zone_bottom = play_data$pitchData$strikeZoneBottom,
+    # Strike zone height is generally rounded to two digits when the batter swings but not when the
+    # batter takes a pitch. We round all strike zone heights to two digits to save future analysts.
+    # Bug details: https://github.com/saberpowers/predictive-pitch-score/pull/36
+    strike_zone_top = round(play_data$pitchData$strikeZoneTop, 2),
+    strike_zone_bottom = round(play_data$pitchData$strikeZoneBottom, 2),
     launch_speed = play_data$hitData$launchSpeed,
     launch_angle = play_data$hitData$launchAngle,
     hit_coord_x = play_data$hitData$coordinates$coordX,


### PR DESCRIPTION
There's a sinister bug uncovered [here](https://github.com/saberpowers/predictive-pitch-score/pull/36). In short, strike zone height is generally rounded to two digits when the batter swings but not when the batter takes a pitch. This PR rounds all strike zone heights to two digits to save future analysts.

Did you ...

- [x] increment the package version number?
- [x] update the changelog (NEWS.md)?