### PR TITLE
Handle non-regular-season games in statsapi download

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -7,7 +7,7 @@ Description: The highest-fidelity raw MLB data are available from statsapi.mlb.c
 License: GPL (>= 3)
 Encoding: UTF-8
 Roxygen: list(markdown = TRUE)
-RoxygenNote: 7.3.2
+RoxygenNote: 7.3.3
 Depends:
   R (>= 4.1.0)
 Imports:

--- a/NEWS.md
+++ b/NEWS.md
@@ -2,6 +2,7 @@
 # sabRmetrics 1.2.0 (in development)
 
 - Round strike zone height from statsapi to 2 decimal places
+- Fix handling of non-regular-season games in `download_statsapi()` (#28)
 
 # sabRmetrics 1.1.0 (2025-07-07)
 

--- a/R/download_statsapi.R
+++ b/R/download_statsapi.R
@@ -30,7 +30,12 @@ download_statsapi <- function(start_date,
                               cl = NULL) {
 
   level <- sanitize_level(level)
-  game <- download_schedule(start_date, end_date, level)
+  game <- download_schedule(
+    start_date = start_date,
+    end_date = end_date,
+    level = level,
+    game_type = game_type
+  )
   year <- lubridate::year(start_date)
 
   data_list <- pbapply::pblapply(


### PR DESCRIPTION
Fix #28 

The problem was that `download_statsapi()` had `game_type` as an argument but neglected to pass that argument to `download_schedule()`.

- [x] run `devtools::document`?
- [x] increment the package version number?
- [x] update the changelog (NEWS.md)?